### PR TITLE
enabled mouse wheel event for scrolling large titles + fixed spell ID…

### DIFF
--- a/Components/Button.lua
+++ b/Components/Button.lua
@@ -131,6 +131,7 @@ function Button:Init(id)
 	self.Counter:SetText(id < 10 and id or '')
 	----------------------------------
 	self:RegisterForDrag('LeftButton', 'RightButton')
+	self:EnableMouseWheel(true)
 	self:OnShow()
 	----------------------------------
 	L.SetBackdrop(self.Overlay, L.Backdrops.GOSSIP_NORMAL)

--- a/Components/Elements.lua
+++ b/Components/Elements.lua
@@ -289,6 +289,7 @@ function Elements:ShowRewards()
 	local numQuestSpellRewards = 0
 	local totalHeight = 0
 	local GetSpell = GetRewardSpell
+	local knownSpell
 
 	do  -- Get data
 		questID = API:GetQuestID()
@@ -304,9 +305,10 @@ function Elements:ShowRewards()
 	do -- Spell rewards
 		for rewardSpellIndex = 1, numSpellRewards do
 			local texture, name, isTradeskillSpell, isSpellLearned = GetSpell(rewardSpellIndex)
-			local spellID = select(7, GetSpellInfo(name))
-			if spellID then
-				local knownSpell = tonumber(spellID) and IsSpellKnown(spellID)
+            local spellLink = GetSpellLink(name)
+			if spellLink then
+				local spellID = string.match(spellLink, "spell:(%d+)")
+				knownSpell = IsSpellKnown(spellID)
 			end
 
 			-- only allow the spell reward if user can learn it
@@ -319,10 +321,10 @@ function Elements:ShowRewards()
 	local totalRewards = numQuestRewards + numQuestChoices + numQuestSpellRewards
 
 	do -- Check if any rewards are present, break out if none
-		if ( totalRewards == 0 and 
-			money == 0 and 
-			xp == 0 and 
-			not playerTitle and 
+		if ( totalRewards == 0 and
+			money == 0 and
+			xp == 0 and
+			not playerTitle and
 			numQuestSpellRewards == 0 ) then
 
 			return self:Hide()
@@ -337,7 +339,7 @@ function Elements:ShowRewards()
 		end
 	end
 
-	-- Setup locals 
+	-- Setup locals
 	local questItem, name, texture, quality, isUsable, numItems
 	local rewardsCount = 0
 	local lastFrame = self.Header
@@ -372,7 +374,7 @@ function Elements:ShowRewards()
 					local link = GetQuestItemLink(questItem.type, i)
 					vendorValue = link and select(11, GetItemInfo(link))
 				end
-				
+
 				if vendorValue and ( not highestValue or vendorValue > highestValue ) then
 					highestValue = vendorValue
 					if vendorValue > 0 and numQuestChoices > 1 then
@@ -428,10 +430,12 @@ function Elements:ShowRewards()
 			-- Generate spell buckets
 			for rewardSpellIndex = 1, numSpellRewards do
 				local texture, name, isTradeskillSpell, isSpellLearned = GetSpell(rewardSpellIndex)
-				local spellID = select(7, GetSpellInfo(name))
-				if spellID then
-					local knownSpell = IsSpellKnown(spellID)
+				local spellLink = GetSpellLink(name)
+				if spellLink then
+					local spellID = string.match(spellLink, "spell:(%d+)")
+					knownSpell = IsSpellKnown(spellID)
 				end
+
 				if IsValidSpellReward(texture, knownSpell, isBoostSpell, garrFollowerID) then
 					local bucket = 	isTradeskillSpell 	and QUEST_SPELL_REWARD_TYPE_TRADESKILL_SPELL or
 									isBoostSpell 		and QUEST_SPELL_REWARD_TYPE_ABILITY or

--- a/Display/Onload.lua
+++ b/Display/Onload.lua
@@ -44,8 +44,7 @@ for _, event in pairs({
 --	'NAME_PLATE_UNIT_REMOVED', 	-- For nameplate mode
 --	ImmersionAPI.IsRetail and 'SUPER_TRACKING_CHANGED',
 --	ImmersionAPI.IsWoW10 and 'PLAYER_INTERACTION_MANAGER_FRAME_SHOW',
--- sirus add events
-	"CHAT_MSG_ADDON",
+	'CHAT_MSG_ADDON',   -- sirus events
 }) do if event then
 		frame:RegisterEvent(event)
 	end
@@ -54,6 +53,7 @@ end
 
 frame.IgnoreResetEvent = {
 	QUEST_ACCEPTED = true,
+	CHAT_MSG_ADDON = true,
 --	NAME_PLATE_UNIT_ADDED = true,
 --	NAME_PLATE_UNIT_REMOVED = true,
 --	SUPER_TRACKING_CHANGED = true,
@@ -63,6 +63,7 @@ frame.IgnoreGossipEvent = {
 	GOSSIP_SHOW = true,
 	GOSSIP_CLOSED = true,
 	QUEST_ACCEPTED = true,
+	CHAT_MSG_ADDON = true,
 --	NAME_PLATE_UNIT_ADDED = true,
 --	NAME_PLATE_UNIT_REMOVED = true,
 --	SUPER_TRACKING_CHANGED = true,

--- a/Immersion.toc
+++ b/Immersion.toc
@@ -1,7 +1,7 @@
 ## Interface: 30300
 ## Title: Immersion
 ## Notes: Immersive replacement for quest & gossip
-## Version: 1.42
+## Version: 1.43
 ## Author: Sebastian Lindfors
 ## SavedVariables: ImmersionSetup
 # OptionalDeps: ConsolePort

--- a/Interface.lua
+++ b/Interface.lua
@@ -212,12 +212,12 @@ end
 -- Gossip API
 function API:CloseGossip(...)
 	if CloseGossip then return CloseGossip(...) end
-	-- return C_GossipInfo.CloseGossip(...)
+	return C_GossipInfo.CloseGossip(...)
 end
 
 function API:ForceGossip(...)
 	if ForceGossip then return ForceGossip(...) end
-	-- return C_GossipInfo.ForceGossip(...)
+	return C_GossipInfo.ForceGossip(...)
 end
 
 function API:CanAutoSelectGossip(dontAutoSelect)
@@ -232,22 +232,22 @@ end
 
 function API:GetGossipText(...)
 	if GetGossipText then return GetGossipText(...) end
-	-- return C_GossipInfo.GetText()
+	return C_GossipInfo.GetText()
 end
 
 function API:GetNumGossipAvailableQuests(...)
 	if GetNumGossipAvailableQuests then return GetNumGossipAvailableQuests(...) end
-	-- return C_GossipInfo.GetNumAvailableQuests(...)
+	return C_GossipInfo.GetNumAvailableQuests(...)
 end
 
 function API:GetNumGossipActiveQuests(...)
 	if GetNumGossipActiveQuests then return GetNumGossipActiveQuests(...) end
-	-- return C_GossipInfo.GetNumActiveQuests(...)
+	return C_GossipInfo.GetNumActiveQuests(...)
 end
 
 function API:GetNumGossipOptions(...)
 	if GetNumGossipOptions then return GetNumGossipOptions(...) end
-	-- return C_GossipInfo.GetNumOptions(...)
+	return C_GossipInfo.GetNumOptions(...)
 end
 
 function API:GetGossipAvailableQuests(...)
@@ -258,7 +258,7 @@ function API:GetGossipAvailableQuests(...)
 			GetGossipAvailableQuests(...)
 		)
 	end
-	-- return C_GossipInfo.GetAvailableQuests(...)
+	return C_GossipInfo.GetAvailableQuests(...)
 end
 
 function API:GetGossipActiveQuests(...)
@@ -269,7 +269,7 @@ function API:GetGossipActiveQuests(...)
 			GetGossipActiveQuests(...)
 		)
 	end
-	-- return C_GossipInfo.GetActiveQuests(...)
+	return C_GossipInfo.GetActiveQuests(...)
 end
 
 function API:GetGossipOptions(...)
@@ -280,7 +280,7 @@ function API:GetGossipOptions(...)
 			GetGossipOptions(...)
 		)
 	end
-	-- return C_GossipInfo.GetOptions(...)
+	return C_GossipInfo.GetOptions(...)
 end
 
 -- Gossip/quest selectors API
@@ -294,17 +294,17 @@ end
 
 function API:SelectGossipOption(...)
 	if SelectGossipOption then return SelectGossipOption(...) end
-	-- return C_GossipInfo.SelectOption(...)
+	return C_GossipInfo.SelectOption(...)
 end
 
 function API:SelectGossipActiveQuest(...)
 	if SelectGossipActiveQuest then return SelectGossipActiveQuest(...) end
-	-- return C_GossipInfo.SelectActiveQuest(...)
+	return C_GossipInfo.SelectActiveQuest(...)
 end
 
 function API:SelectGossipAvailableQuest(...)
 	if SelectGossipAvailableQuest then return SelectGossipAvailableQuest(...) end
-	-- return C_GossipInfo.SelectAvailableQuest(...)
+	return C_GossipInfo.SelectAvailableQuest(...)
 end
 
 -- Misc


### PR DESCRIPTION
- добавил возможность скролить большие диалоги
- исправил ошибку со спеллами (которую когда-то и репортил) https://discord.com/channels/914079030125420565/1113654927940653106
- исправил всему надоевшую ошибку с автозакрытием диалогового окна. (https://discord.com/channels/914079030125420565/1195779930282262639) Связана трабла была с событием CHAT_MSG_ADDON. Добавил в  IgnoreResetEvent и в IgnoreGossipEvent. Протестил на монетке и паре рандомных кв, вроде работает теперь корректно + твоя правка на аук и трансмог по прежнему работает :)