### PR TITLE
fix CastSpell from spellbook + raidmarkers

### DIFF
--- a/Immersion.toc
+++ b/Immersion.toc
@@ -1,7 +1,7 @@
 ## Interface: 30300
 ## Title: Immersion
 ## Notes: Immersive replacement for quest & gossip
-## Version: 1.43
+## Version: 1.44
 ## Author: Sebastian Lindfors
 ## SavedVariables: ImmersionSetup
 # OptionalDeps: ConsolePort

--- a/Methods/Extensions.lua
+++ b/Methods/Extensions.lua
@@ -30,7 +30,7 @@ end
 -- Frame Mixin (General)
 ----------------------------------
 local FrameMixin = {}
-FrameMixin.ignoreParent = CreateFrame("Frame", nil, WorldFrame)
+FrameMixin.ignoreParent = CreateFrame("Frame", "ImmersionFrame", WorldFrame)
 function FrameMixin:SetShown(shown)
     if shown then
         self:Show()


### PR DESCRIPTION
проблема, на которую я убил тонну времени и не понимаю почему без имени фрейма сирусовские фреймы думают, что их пытаются переписать?

проблема с рейд маркерами и кнопками из спеллбука пофикшена. 

Касаемо https://discord.com/channels/914079030125420565/1113438089004732447, можно поднять strata для этих кнопок. PR https://github.com/fxpw/ElvUI_Enhanced/pull/2